### PR TITLE
Sanitize path also for regular ones

### DIFF
--- a/lib/mix/tasks/utils.ex
+++ b/lib/mix/tasks/utils.ex
@@ -169,12 +169,12 @@ defmodule ExRM.Release.Utils do
   defp get_real_path(path) do
     case path |> String.to_char_list! |> :file.read_link_info do
       {:ok, {:file_info, _, :regular, _, _, _, _, _, _, _, _, _, _, _}} ->
-        path |> String.replace("/bin/elixir", "")
+        path
       {:ok, {:file_info, _, :symlink, _, _, _, _, _, _, _, _, _, _, _}} ->
         {:ok, sym} = path |> String.to_char_list! |> :file.read_link
         symlink    = sym |> iolist_to_binary
-        path |> Path.dirname |> Path.join(symlink) |> Path.expand |> String.replace("/bin/elixir", "")
-    end
+        path |> Path.dirname |> Path.join(symlink) |> Path.expand
+    end |> String.replace("/bin/elixir", "")
   end
 
 end


### PR DESCRIPTION
Otherwise I'll get this error (if the path is a `regular` instead of `symlink` one):

``` elixir
==> Generating boot script...
==> Generating release...
error (enotdir) accessing file /home/chris/.exenv/versions/0.13.0.dev/bin/elixir/lib

==> Failed to build release. Please fix any errors and try again.
```

---

(+ whitespace removal, newline at EOL)
