### PR TITLE
Solaris and non posix shell compatibility

### DIFF
--- a/priv/rel/files/runner
+++ b/priv/rel/files/runner
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 


### PR DESCRIPTION
The runner script currently uses some syntax specific to posix-compliant shells. sh is not posix-compatible on solaris and some non-linux OSes. Bash is, and this change simply changes the runner shebang to use bash instead of sh.

Thanks
