### PR TITLE
Updating deprecated binary_to_atom and atom_to_binary calls

### DIFF
--- a/lib/exrm/appups.ex
+++ b/lib/exrm/appups.ex
@@ -19,12 +19,12 @@ defmodule ReleaseManager.Appups do
     v1_release =
       v1_path
       |> Path.join("/ebin/")
-      |> Path.join(atom_to_binary(application) <> ".app")
+      |> Path.join(Atom.to_string(application) <> ".app")
       |> String.to_char_list
     v2_release =
       v2_path
       |> Path.join("/ebin/")
-      |> Path.join(atom_to_binary(application) <> ".app")
+      |> Path.join(Atom.to_string(application) <> ".app")
       |> String.to_char_list
 
     case :file.consult(v1_release) do
@@ -60,7 +60,7 @@ defmodule ReleaseManager.Appups do
           start_mod_beam_file =
             v2_path
             |> Path.join("/ebin/")
-            |> Path.join(atom_to_binary(start_mod) <> ".beam")
+            |> Path.join(Atom.to_string(start_mod) <> ".beam")
           { start_mod_beam_file |> File.read! |> version_change(v1, start_mod, start_args),
             start_mod_beam_file |> File.read! |> version_change({:down, v1}, start_mod, start_args) }
         :undefined ->
@@ -69,14 +69,14 @@ defmodule ReleaseManager.Appups do
 
     up_directives =
       (modules(v2_props) -- add_mods) |> Enum.map(fn module ->
-        (v2_path <> "/ebin/" <> atom_to_binary(module) <> ".beam")
+        (v2_path <> "/ebin/" <> Atom.to_string(module) <> ".beam")
         |> File.read!
         |> upgrade_directives(v1, v2, module)
       end) |> List.flatten
 
     down_directives =
       Enum.reverse(modules(v2_props) -- add_mods) |> Enum.map(fn module ->
-        (v2_path <> "/ebin/" <> atom_to_binary(module) <> ".beam")
+        (v2_path <> "/ebin/" <> Atom.to_string(module) <> ".beam")
         |> File.read!
         |> downgrade_directives(v1, v2, module)
       end) |> List.flatten
@@ -102,7 +102,7 @@ defmodule ReleaseManager.Appups do
     # Save the appup to the upgrade's build directory
     v2_path
     |> Path.join("ebin")
-    |> Path.join((application |> atom_to_binary) <> ".appup")
+    |> Path.join((application |> Atom.to_string) <> ".appup")
     |> write_term(appup)
 
     { :ok, appup }

--- a/lib/exrm/plugin.ex
+++ b/lib/exrm/plugin.ex
@@ -79,7 +79,7 @@ defmodule ReleaseManager.Plugin do
   @spec match_plugins(char_list, [atom]) :: [atom]
   defp match_plugins(filename, modules) do
     if :re.run(filename, @re_pattern, [capture: :none]) == :match do
-      mod = :filename.rootname(filename, '.beam') |> list_to_atom
+      mod = :filename.rootname(filename, '.beam') |> List.to_atom
       if Code.ensure_loaded?(mod), do: [mod | modules], else: modules
     else
       modules

--- a/lib/exrm/utils.ex
+++ b/lib/exrm/utils.ex
@@ -233,9 +233,9 @@ defmodule ReleaseManager.Utils do
         {:ok, sym} = path |> String.to_char_list |> :file.read_link
         case sym |> :filename.pathtype do
           :absolute ->
-            sym |> iodata_to_binary
+            sym |> IO.iodata_to_binary
           :relative ->
-            symlink = sym |> iodata_to_binary
+            symlink = sym |> IO.iodata_to_binary
             path |> Path.dirname |> Path.join(symlink) |> Path.expand
         end
     end |> String.replace("/bin/elixir", "")

--- a/lib/mix/tasks/release.clean.ex
+++ b/lib/mix/tasks/release.clean.ex
@@ -51,7 +51,7 @@ defmodule Mix.Tasks.Release.Clean do
   # Clean release build
   def do_cleanup(:build) do
     cwd       = File.cwd!
-    project   = Mix.Project.config |> Keyword.get(:app) |> atom_to_binary
+    project   = Mix.Project.config |> Keyword.get(:app) |> Atom.to_string
     version   = Mix.Project.config |> Keyword.get(:version)
     build     = Path.join([cwd, "_build", "prod"])
     release   = rel_dest_path [project, "releases", version]
@@ -106,7 +106,7 @@ defmodule Mix.Tasks.Release.Clean do
   defp confirm_implode?(app) do
     IO.puts IO.ANSI.yellow
     confirmed? = Mix.Shell.IO.yes?("""
-      THIS WILL REMOVE ALL RELEASES AND RELATED CONFIGURATION FOR #{app |> atom_to_binary |> String.upcase}!
+      THIS WILL REMOVE ALL RELEASES AND RELATED CONFIGURATION FOR #{app |> Atom.to_string |> String.upcase}!
       Are you absolutely sure you want to proceed?
       """)
     IO.puts IO.ANSI.reset

--- a/lib/mix/tasks/release.ex
+++ b/lib/mix/tasks/release.ex
@@ -173,7 +173,7 @@ defmodule Mix.Tasks.Release do
   end
 
   defp generate_boot_script(%Config{name: name, version: version, erl: erl_opts} = config) do
-    erts = :erlang.system_info(:version) |> iodata_to_binary
+    erts = :erlang.system_info(:version) |> IO.iodata_to_binary
     boot = rel_file_source_path @_BOOT_FILE
     dest = rel_file_dest_path   @_BOOT_FILE
     # Ensure destination base path exists
@@ -233,7 +233,7 @@ defmodule Mix.Tasks.Release do
       # Change mix env for appup generation
       with_env :prod do
         # Generate appup
-        app      = name |> binary_to_atom
+        app      = name |> String.to_atom
         v1       = get_last_release(name)
         v1_path  = rel_dest_path [name, "lib", "#{name}-#{v1}"]
         v2_path  = Mix.Project.config |> Mix.Project.compile_path |> String.replace("/ebin", "")
@@ -277,7 +277,7 @@ defmodule Mix.Tasks.Release do
   defp generate_nodetool(%Config{name: name, version: version} = config) do
     nodetool = rel_file_source_path @_NODETOOL
     dest     = rel_dest_path [name, "bin", @_NODETOOL]
-    erts     = "erts-#{:erlang.system_info(:version) |> iodata_to_binary}"
+    erts     = "erts-#{:erlang.system_info(:version) |> IO.iodata_to_binary}"
     debug "Generating nodetool..."
     # Copy
     File.cp! nodetool, dest
@@ -310,13 +310,13 @@ defmodule Mix.Tasks.Release do
   defp parse_args(argv) do
     {args, _, _} = OptionParser.parse(argv)
     defaults = %Config{
-      name:    Mix.Project.config |> Keyword.get(:app) |> atom_to_binary,
+      name:    Mix.Project.config |> Keyword.get(:app) |> Atom.to_string,
       version: Mix.Project.config |> Keyword.get(:version),
     }
     Enum.reduce args, defaults, fn arg, config ->
       case arg do
         {:verbosity, verbosity} ->
-          %{config | :verbosity => binary_to_atom(verbosity)}
+          %{config | :verbosity => String.to_atom(verbosity)}
         {key, value} ->
           Map.put(config, key, value)
       end


### PR DESCRIPTION
Requires updates in the `develop` branch of `conform` (bitwalker/confrom#3)
