### PR TITLE
Do not include Erlang library sources in the release

### DIFF
--- a/priv/rel/relx.config
+++ b/priv/rel/relx.config
@@ -14,6 +14,9 @@
 %% ERTS is included by default, but let's be explicit
 {include_erts, true}.
 
+%% Do not ship Erlang library sources as part of the release
+{include_src, false}.
+
 %% TODO: Support providing a sys.config file
 %% {sys_config, "./path/to/sys.config"}.
 


### PR DESCRIPTION
This cuts down 6 MB on the uncompressed size of the release.
