### PR TITLE
Change with_env to a function

### DIFF
--- a/lib/exrm/plugins/consolidation.ex
+++ b/lib/exrm/plugins/consolidation.ex
@@ -6,7 +6,7 @@ defmodule ReleaseManager.Plugin.Consolidation do
 
   def before_release(%Config{verbosity: verbosity}) do
     debug "Performing protocol consolidation..."
-    with_env :prod do
+    with_env :prod, fn ->
       cond do
         verbosity == :verbose ->
           mix "compile.protocols", :prod, :verbose

--- a/lib/exrm/utils.ex
+++ b/lib/exrm/utils.ex
@@ -12,15 +12,15 @@ defmodule ReleaseManager.Utils do
   @doc """
   Perform some actions within the context of a specific mix environment
   """
-  defmacro with_env(env, body) do
-    quote do
-      old_env = Mix.env
+  def with_env(env, fun) do
+    old_env = Mix.env
+    try do
       # Change env
-      Mix.env(unquote(env))
-      result = unquote(body)
+      Mix.env(env)
+      fun.()
+    after
       # Change back
       Mix.env(old_env)
-      result
     end
   end
 
@@ -28,7 +28,7 @@ defmodule ReleaseManager.Utils do
   Load the current project's configuration
   """
   def load_config() do
-    with_env :prod do
+    with_env :prod, fn ->
       if File.regular?("config/config.exs") do
         Mix.Config.read! "config/config.exs"
       else

--- a/lib/mix/tasks/release.ex
+++ b/lib/mix/tasks/release.ex
@@ -232,7 +232,7 @@ defmodule Mix.Tasks.Release do
     # If this is an upgrade release, generate an appup
     if upgrade? do
       # Change mix env for appup generation
-      with_env :prod do
+      with_env :prod, fn ->
         # Generate appup
         app      = name |> String.to_atom
         v1       = get_last_release(name)


### PR DESCRIPTION
Fixes a bug where `with_env` would return `[do: result_of_block]`. Also wraps the env changing in a `try .. after` to ensure env is correct after failures.
