### PR TITLE
Remove options perventing foreground mode from working.

### DIFF
--- a/priv/rel/files/boot
+++ b/priv/rel/files/boot
@@ -390,10 +390,9 @@ case "$1" in
 
         # Build an array of arguments to pass to exec later on
         # Build it here because this command will be used for logging.
-        set -- "$BINDIR/erlexec" "$FOREGROUNDOPTIONS" \
+        set -- "$BINDIR/erlexec" $FOREGROUNDOPTIONS \
             -boot "$REL_DIR/$BOOTFILE" -mode embedded -config "$CONFIG_PATH" \
-            -args_file "$VMARGS_PATH" \
-            -user Elixir.IEx.CLI -extra --no-halt +iex
+            -args_file "$VMARGS_PATH"
 
         # Dump environment info for logging purposes
         echo "Exec: $@" -- "${1+$ARGS}"


### PR DESCRIPTION
I was attempting to use foreground mode to create an Ubuntu Upstart script and noticed that it still opens a shell. I changed the 2 things that were preventing it and now it successfully works in foreground and Upstart.
