### PR TITLE
added support to build the release for any mix environment

### DIFF
--- a/lib/exrm/config.ex
+++ b/lib/exrm/config.ex
@@ -7,6 +7,7 @@ defmodule ReleaseManager.Config do
       name:      The name of your application
       version:   The version of your application
       dev?:      Is this release being built in dev mode
+      env:       The mix environment the app should be build for
       erl:       The binary containing all options to pass to erl
       upgrade?:  Is this release an upgrade?
       verbosity: The verbosity level, one of [silent|quiet|normal|verbose]
@@ -15,6 +16,7 @@ defmodule ReleaseManager.Config do
   defstruct name:      "",
             version:   "",
             dev:       false,
+            env:       :prod,
             erl:       "",
             upgrade?:  false,
             verbosity: :quiet,

--- a/lib/exrm/utils.ex
+++ b/lib/exrm/utils.ex
@@ -26,8 +26,8 @@ defmodule ReleaseManager.Utils do
   @doc """
   Load the current project's configuration
   """
-  def load_config() do
-    with_env :prod, fn ->
+  def load_config(env) do
+    with_env env, fn ->
       if File.regular?("config/config.exs") do
         Mix.Config.read! "config/config.exs"
       else

--- a/test/utils_test.exs
+++ b/test/utils_test.exs
@@ -41,9 +41,9 @@ defmodule UtilsTest do
     assert :prod = execution_env
   end
 
-  test "can load the current project configuration" do
+  test "can load the current project configuration for a given environment" do
     with_app do
-      [test: config] = Utils.load_config
+      [test: config] = Utils.load_config(:prod)
       assert List.keymember?(config, :foo, 0)
     end
   end


### PR DESCRIPTION
As described in #60, building releases for different mix environments would be an important feature for us to have. To get to know this tool it a bit better I gave it a shot.

As suggested by @ericmj I changed it to read the MIX_ENV variable

```
MIX_ENV=staging mix release
```

I tested it for our deployment and it seems to work the way we need it work (I haven't tested appups though). Let me know if you want me to apply additional changes.

If you worked on that already or dislike my solution don't hesitate to simply ignore this PR ;-)
