### PR TITLE
Make tasks that fail exit with exit status 1.

### DIFF
--- a/lib/exrm/utils.ex
+++ b/lib/exrm/utils.ex
@@ -94,6 +94,9 @@ defmodule ReleaseManager.Utils do
   @doc "Print an error message in red"
   def error(message), do: IO.puts "==> #{IO.ANSI.red}#{message}#{IO.ANSI.reset}"
 
+  @doc "Exits with exit status 1"
+  def abort!, do: exit({:shutdown, 1})
+
   @doc """
   Get a list of tuples representing the previous releases:
 
@@ -153,10 +156,10 @@ defmodule ReleaseManager.Utils do
         terms
       {:error, {line, type, msg}} ->
         error "Unable to parse #{path}: Line #{line}, #{type}, - #{msg}"
-        exit(:normal)
+        abort!
       {:error, reason} ->
         error "Unable to access #{path}: #{reason}"
-        exit(:normal)
+        abort!
     end
     result
   end

--- a/lib/mix/tasks/release.ex
+++ b/lib/mix/tasks/release.ex
@@ -277,7 +277,7 @@ defmodule Mix.Tasks.Release do
                 info "Using custom .appup located in rel/#{name}.appup"
               {:error, reason} ->
                 error "Unable to copy custom .appup file: #{reason}"
-                exit(:normal)
+                abort!
             end
           _ ->
             # No custom .appup found, proceed with autogeneration
@@ -286,7 +286,7 @@ defmodule Mix.Tasks.Release do
                 info "Generated .appup for #{name} #{v1} -> #{version}"
               {:error, reason} ->
                 error "Appup generation failed with #{reason}"
-                exit(:normal)
+                abort!
             end
         end
       end
@@ -300,7 +300,7 @@ defmodule Mix.Tasks.Release do
         config
       {:error, message} ->
         error message
-        exit(:normal)
+        abort!
     end
   end
 

--- a/lib/mix/tasks/release.plugins.ex
+++ b/lib/mix/tasks/release.plugins.ex
@@ -48,7 +48,7 @@ defmodule Mix.Tasks.Release.Plugins do
     case result do
       nil ->
         notice "No plugin by that name could be found!"
-        exit(:normal)
+        abort!
       _ ->
         result
     end
@@ -87,7 +87,7 @@ defmodule Mix.Tasks.Release.Plugins do
       {_, [plugin], _} -> [action: :details, plugin: plugin]
       {_, _, _} ->
         error "Invalid arguments for `mix release.plugins`!"
-        exit(:normal)
+        abort!
     end
   end
 


### PR DESCRIPTION
We run `mix release` in our CI flow.