### PR TITLE
Add semver version compare

### DIFF
--- a/lib/exrm/utils.ex
+++ b/lib/exrm/utils.ex
@@ -121,7 +121,15 @@ defmodule ReleaseManager.Utils do
   Get the most recent release prior to the current one
   """
   def get_last_release(project) do
-    [{_,version} | _] = project |> get_releases |> Enum.sort(fn {_, v1}, {_, v2} -> v1 > v2 end)
+    [{_,version} | _] = project |> get_releases |> Enum.sort(
+      fn {_, v1}, {_, v2} ->
+        {:ok, v1} = Version.parse(v1)
+        {:ok, v2} = Version.parse(v2)
+        case Version.compare(v1, v2) do
+          :gt -> true
+          _ -> false
+        end
+      end)
     version
   end
 

--- a/lib/exrm/utils.ex
+++ b/lib/exrm/utils.ex
@@ -146,7 +146,7 @@ defmodule ReleaseManager.Utils do
   end
 
   defp is_semver?(vsn) do
-    Regex.match?(~r/^\d+\.\d+\.\d+/, vsn)
+    Version.parse(vsn) !== :error
   end
 
   @doc """

--- a/test/utils_test.exs
+++ b/test/utils_test.exs
@@ -78,4 +78,12 @@ defmodule UtilsTest do
     end
   end
 
+  test "can compare semver versions" do
+    assert ["1.0.10"|_] = Utils.sort_versions(["1.0.1", "1.0.2", "1.0.9", "1.0.10"])
+  end
+
+  test "can compare non-semver versions" do
+    assert ["1.3", "1.2", "1.1"] = Utils.sort_versions(["1.1", "1.3", "1.2"])
+  end
+  
 end


### PR DESCRIPTION
See #110 

Fallback for non-semver versions is in place which uses regular string comparison.
One test is not running for me locally but also not on local master branch, so that one seems unrelated.