### PR TITLE
Added defcallback for after_cleanup/1 in the ReleaseManager.Plugin behaviour

### DIFF
--- a/lib/exrm/config.ex
+++ b/lib/exrm/config.ex
@@ -11,6 +11,7 @@ defmodule ReleaseManager.Config do
       erl:       The binary containing all options to pass to erl
       upgrade?:  Is this release an upgrade?
       verbosity: The verbosity level, one of [silent|quiet|normal|verbose]
+      package:   Path to the generated release package.
 
   """
   defstruct name:      "",
@@ -20,5 +21,6 @@ defmodule ReleaseManager.Config do
             erl:       "",
             upgrade?:  false,
             verbosity: :quiet,
-            relx_config: []
+            relx_config: [],
+            package:   nil
 end

--- a/lib/exrm/plugin.ex
+++ b/lib/exrm/plugin.ex
@@ -17,6 +17,10 @@ defmodule ReleaseManager.Plugin do
           info "This is executed just after compiling the release"
         end
 
+        def after_package(%Config{} = config) do
+          info "This is executed just after packaging the release"
+        end
+
         def after_cleanup(_args) do
           info "This is executed just after running cleanup"
         end
@@ -48,6 +52,7 @@ defmodule ReleaseManager.Plugin do
   """
   defcallback before_release(ReleaseManager.Config.t) :: any
   defcallback after_release(ReleaseManager.Config.t) :: any
+  defcallback after_package(ReleaseManager.Config.t) :: any
   defcallback after_cleanup([String.t]) :: any
 
   @doc false

--- a/lib/exrm/plugin.ex
+++ b/lib/exrm/plugin.ex
@@ -43,10 +43,12 @@ defmodule ReleaseManager.Plugin do
 
   @doc """
   A plugin needs to implement `before_release/1`, and `after_release/1`
-  both of which receive a %ReleaseManager.Config struct
+  both of which receive a %ReleaseManager.Config struct, as well as `after_cleanup/1`, which
+  receives the arguments given for the command as a list of strings.
   """
   defcallback before_release(ReleaseManager.Config.t) :: any
   defcallback after_release(ReleaseManager.Config.t) :: any
+  defcallback after_cleanup([String.t]) :: any
 
   @doc false
   defmacro __using__(_opts) do

--- a/lib/exrm/plugins/conform.ex
+++ b/lib/exrm/plugins/conform.ex
@@ -67,6 +67,7 @@ defmodule ReleaseManager.Plugin.Conform do
   end
 
   def after_release(_), do: nil
+  def after_package(_), do: nil
   def after_cleanup(_), do: nil
 
 end

--- a/lib/exrm/plugins/consolidation.ex
+++ b/lib/exrm/plugins/consolidation.ex
@@ -31,5 +31,6 @@ defmodule ReleaseManager.Plugin.Consolidation do
   end
 
   def after_release(_), do: nil
+  def after_package(_), do: nil
   def after_cleanup(_), do: nil
 end


### PR DESCRIPTION
The `ReleaseManager.Plugin` behaviour was missing the `defcallback` for `after_cleanup/1`. This pull request simply adds that so that the compiler will give a warning for a plugin that does not have that implemented.