### PR TITLE
Detect local ERTS version automatically

### DIFF
--- a/priv/rel/files/boot
+++ b/priv/rel/files/boot
@@ -25,7 +25,7 @@ find_erts_dir() {
         local erl="$(which erl)"
         local code="io:format(\"~s\", [code:root_dir()])."
         local erl_root="$("$erl" -noshell -eval "$code" -s init stop)"
-        ERTS_DIR="$erl_root/erts-$ERTS_VSN"
+        ERTS_DIR=$(ls -d $erl_root/erts-* | sort -t '.' -k 1,1 -k 2,2 -k 3,3 -k 4,4 -k 5,5 -g | tail -n 1)
         ROOTDIR="$erl_root"
     fi
 }

--- a/test/utils_test.exs
+++ b/test/utils_test.exs
@@ -63,7 +63,7 @@ defmodule UtilsTest do
   end
 
   @tag :expensive
-  @tag timeout: 60000 # 60s
+  @tag timeout: 120000 # 120s
   test "can build a release and boot it up" do
     with_app do
       # Build release


### PR DESCRIPTION
This change allows running a release without an included ERTS version to use any Erlang version on the target host, not only the one used to build the release.