### PR TITLE
Catch up with relx's change in install_upgrade.escript

### DIFF
--- a/priv/rel/files/boot
+++ b/priv/rel/files/boot
@@ -364,7 +364,25 @@ case "$1" in
         fi
 
         exec "$BINDIR/escript" "$ROOTDIR/bin/install_upgrade.escript" \
-             "$REL_NAME" "$NAME" "$COOKIE" "$2"
+             "install" "$REL_NAME" "$NAME" "$COOKIE" "$2"
+        ;;
+
+    unpack)
+        if [ -z "$2" ]; then
+            echo "Missing package argument"
+            echo "Usage: $REL_NAME $1 {package base name}"
+            echo "NOTE {package base name} MUST NOT include the .tar.gz suffix"
+            exit 1
+        fi
+
+        # Make sure a node IS running
+        if ! relx_nodetool "ping" > /dev/null; then
+            echo "Node is not running!"
+            exit 1
+        fi
+
+        exec "$BINDIR/escript" "$ROOTDIR/bin/install_upgrade.escript" \
+             "unpack" "$REL_NAME" "$NAME" "$COOKIE" "$2"
         ;;
 
     console|console_clean|console_boot)


### PR DESCRIPTION
Currently I can create a release using `mix release` and start the generated release,
but unfortunately upgrade and a few other options are not correctly working.
To reproduce:
```sh
$ git clone https://github.com/bitwalker/exrm-test.git && cd exrm-test
...
$ mix deps.get && mix release
...
$ cd rel/test
$ ./bin/test start
$ ./bin/test upgrade "0.0.1" # This should output "Release 0.0.1 is already installed, and set permanent.", but nothing printed.
$ echo $?
1
```
I'm using elixir 1.0.4 and exrm 0.17.1 (as I tested with [this version](https://github.com/bitwalker/exrm-test/commit/114afb76a83a6329b5ca416d720e5a5f48adf408) of [exrm-test`](https://github.com/bitwalker/exrm-test)).

The problem is due to a mismatch in the arguments passed to `bin/install_upgrade.escript` in `bin/test`.
On the [relx](https://github.com/erlware/relx) side `install_upgrade.escript` has been modified by [this commit](https://github.com/erlware/relx/commit/358eb115ddf1530939b1273e88e7f38271b2a3de).
This PR is just applying the modification of the commit to exrm's `priv/rel/files/boot` script.
Thanks in advance!