### PR TITLE
Fixing the issue of a running server pipes in /tmp directory

### DIFF
--- a/lib/mix/tasks/release.ex
+++ b/lib/mix/tasks/release.ex
@@ -353,7 +353,7 @@ defmodule Mix.Tasks.Release do
     end
     # Re-package release with modifications
     file_list = File.ls!(rel_dest_path(name))
-      |> Enum.reject(&(&1 == erts))
+      |> Enum.reject(fn n -> n in [erts, "tmp"] end)
       |> Enum.map(&({'#{&1}', '#{rel_dest_path([name, &1])}'}))
     :ok = :erl_tar.create(
       '#{tarball}',


### PR DESCRIPTION
If I have a running server and try to make a release, it fails with an error, since function
```
:ok = :erl_tar.create()
```
does not recognize the format of pipes. And they should also not be there. 


The error that this fixes is the following:
```
mix stdout: ==> Building release with MIX_ENV=prod.
==> Generating relx configuration...
==> Generating sys.config...
==> Generating boot script...
==> Conform: Loading schema...
==> Conform: No schema found, conform will not be packaged in this release!
==> Performing protocol consolidation...
==> Generating release...
==> Generated .appup for elixir_stream 0.0.1 -> 0.0.2
/usr/local/bin/mix:2: syntax error before: '#'
/usr/local/bin/mix:2: syntax error before: '#'
/usr/local/bin/mix:2: syntax error before: '#'
/usr/local/bin/mix:2: syntax error before: '#'
/usr/local/bin/mix:2: syntax error before: '#'
/usr/local/bin/mix:2: syntax error before: '#'
/usr/local/bin/mix:2: syntax error before: '#'
/usr/local/bin/mix:2: syntax error before: '#'
/usr/local/bin/mix:2: syntax error before: '#'
===> relup successfully created!
==> Generating nodetool...
==> Packaging release...
mix stderr: ** (MatchError) no match of right hand side value: {:error, {:bad_file_type, '/var/www/myapp/releases/20150626075959/rel/myapp/tmp/erl_pipes/myapp/erlang.pipe.1.r', :other}}
    lib/mix/tasks/release.ex:358: Mix.Tasks.Release.update_release_package/1
    lib/mix/tasks/release.ex:73: Mix.Tasks.Release.do_run/1
    (mix) lib/mix/cli.ex:55: Mix.CLI.run_task/2
    (elixir) lib/code.ex:307: Code.require_file/2
```