### PR TITLE
Fix Elixir lib path detection when using version managers

### DIFF
--- a/lib/exrm/utils.ex
+++ b/lib/exrm/utils.ex
@@ -155,8 +155,11 @@ defmodule ReleaseManager.Utils do
   @doc """
   Get the local path of the current elixir executable
   """
-  def get_elixir_path() do
-    System.find_executable("elixir") |> get_real_path
+  def get_elixir_lib_path() do
+    [elixir_lib_path, _ ] = "#{:code.which(Mix)}"
+    |> String.split "mix/ebin/Elixir.Mix.beam"
+
+    elixir_lib_path
   end
 
   @doc """

--- a/lib/exrm/utils.ex
+++ b/lib/exrm/utils.ex
@@ -309,20 +309,4 @@ defmodule ReleaseManager.Utils do
     end
   end
 
-  defp get_real_path(path) do
-    case path |> String.to_char_list |> :file.read_link_info do
-      {:ok, {:file_info, _, :regular, _, _, _, _, _, _, _, _, _, _, _}} ->
-        path
-      {:ok, {:file_info, _, :symlink, _, _, _, _, _, _, _, _, _, _, _}} ->
-        {:ok, sym} = path |> String.to_char_list |> :file.read_link
-        case sym |> :filename.pathtype do
-          :absolute ->
-            sym |> IO.iodata_to_binary
-          :relative ->
-            symlink = sym |> IO.iodata_to_binary
-            path |> Path.dirname |> Path.join(symlink) |> Path.expand
-        end
-    end |> String.replace(~r(/bin/elixir$), "")
-  end
-
 end

--- a/lib/mix/tasks/release.ex
+++ b/lib/mix/tasks/release.ex
@@ -109,7 +109,7 @@ defmodule Mix.Tasks.Release do
       "" -> config
       _  -> %{config | :upgrade? => true}
     end
-    elixir_path = get_elixir_path() |> Path.join("lib") |> String.to_char_list
+    elixir_path = get_elixir_lib_path() |> String.to_char_list
     lib_dirs = case Mix.Project.config |> Keyword.get(:umbrella?, false) do
       true ->
         [ elixir_path,

--- a/test/utils_test.exs
+++ b/test/utils_test.exs
@@ -56,7 +56,7 @@ defmodule UtilsTest do
   end
 
   test "can get the current elixir library path" do
-    path        = Path.join([Utils.get_elixir_path, "bin", "elixir"])
+    path        = Path.join(Utils.get_elixir_lib_path, "../bin/elixir")
     {result, _} = System.cmd(path, ["--version"])
     version     = result |> String.strip(?\n)
     assert "Elixir #{System.version}" == version


### PR DESCRIPTION
This change fixes & simplifies calculating Elixir lib path using the path to Mix's beam file as a reference point. Works with both normal pkg install and also version managers.

Most version managers use shims, which makes the `ReleaseManager.Utils.get_real_path/1` point to `~/.asdf/shims/elixir`. This results in the elixir lib path being assumed as `~/.asdf/shims/elixir/lib`, which is non-existent, which is written to `relx.config`. And exrm/relx errors out when making a release while searching for iex in that path.

Tested this change with Erlang 18.0 & Elixir 1.0.5 on:
* [asdf](http://github.com/HashNuke/asdf) version manager on OS X El Capitan
* Erlang Solutions Elixir package on Ubuntu 14.04 on Vagrant (screenshot attached)
![screen shot 2015-07-02 at 10 47 46 am](https://cloud.githubusercontent.com/assets/84005/8470529/5f6da13a-20aa-11e5-91df-2a46e7e731dd.png)

Thanks to @tsloughter for helping out.

@bitwalker please let me know if you need any info or if there's anything to be changed.

[Ref: [twitter conversation](https://twitter.com/HashNuke/status/616440766227857408)]