### PR TITLE
Pass similar args to foreground as to console/start

### DIFF
--- a/priv/rel/files/boot
+++ b/priv/rel/files/boot
@@ -490,6 +490,8 @@ case "$1" in
         set -- "$BINDIR/erlexec" $FOREGROUNDOPTIONS \
             -boot "$REL_DIR/$BOOTFILE" -mode embedded -config "$SYS_CONFIG" \
             -boot_var ERTS_LIB_DIR "$ERTS_LIB_DIR" \
+            -pa "$REL_LIB_DIR/consolidated" \
+            -env ERL_LIBS "$REL_LIB_DIR" \
             -args_file "$VMARGS_PATH"
 
         # Dump environment info for logging purposes


### PR DESCRIPTION
I was using foreground in production to run with upstart and noticed a bit of contention and it turns out my code was constantly hitting the code server for protocols. This makes Foreground start the same way as start/console.