### PR TITLE
add testing against empty PID in boot scrip

### DIFF
--- a/priv/rel/files/boot
+++ b/priv/rel/files/boot
@@ -292,6 +292,10 @@ case "$1" in
         if [ "$exit_status" -ne 0 ]; then
             exit $exit_status
         fi
+        # ensuring PID is not empty
+        if [ -z "$PID" ]; then
+            exit 0
+        fi
         while $(kill -0 "$PID" 2>/dev/null);
         do
             sleep 1


### PR DESCRIPTION
The current code assumes that 
```
kill -0 ""
```
is answered with an error code, which happens with the core util's kill.
Although the application stopped accordingly, the above assumption 
lead to indefinite waiting on a machine using busybox.