### PR TITLE
always copy release-config to running-config

### DIFF
--- a/priv/rel/files/boot
+++ b/priv/rel/files/boot
@@ -103,12 +103,12 @@ generate_config() {
     if [ -f "$__schema_file" ]; then
         if [ -f "$__conform_file" ]; then
             __running_conf="$GENERATED_CONFIG_DIR/$REL_NAME.conf"
-            if [ ! -f "$__running_conf" ]; then
-                cp "$__conform_file" "$__running_conf"
-                __conform_file="$__running_conf"
-            else
-                __conform_file="$__running_conf"
-            fi
+
+            # always copy release-config to running-config
+            echo "copying $__conform_file to $__running_conf ..."
+            cp "$__conform_file" "$__running_conf"
+            __conform_file="$__running_conf"
+
             echo "using $__conform_file to populate \"$GENERATED_CONFIG_DIR\"."
             __conform="$REL_DIR/conform"
             # Handle the case where the current version did not bundle conform in the release


### PR DESCRIPTION
context: boot-script (priv/rel/files/boot)

currently  `generate_config()` copies the `$RELEASE_CONFIG_FILE` to `$GENERATED_CONFIG_DIR` and then runs `conform` on it to create `$GENERATED_CONFIG_DIR/sys.config`.

The problem: `generate_config()` does not copy `$RELEASE_CONFIG_FILE` if the target already exists. This causes configuration changes not being picked up after the first boot.

This MR changes the behavior to **always** copy the `$RELEASE_CONFIG_FILE` before running `conform`.

(The above is also true when `$RELEASE_CONFIG_FILE` is not set; in which case `$RELEASE_CONFIG_DIR/$REL_NAME.conf` is used as the source for (not) copying.)