### PR TITLE
Add running_conf to init arguments

### DIFF
--- a/priv/rel/files/boot
+++ b/priv/rel/files/boot
@@ -104,6 +104,7 @@ generate_config() {
     if [ -f "$__schema_file" ]; then
         if [ -f "$__conform_file" ]; then
             __running_conf="$GENERATED_CONFIG_DIR/$REL_NAME.conf"
+            CONFORM_OPTS="-conform_schema ${__schema_file} -conform_config ${__conform_file} -running_conf ${__running_conf}"
 
             # always copy release-config to running-config
             echo "copying $__conform_file to $__running_conf ..."
@@ -116,7 +117,6 @@ generate_config() {
             if [ ! -f "$__conform" ]; then
                 __conform="$ROOTDIR/bin/conform"
             fi
-            CONFORM_OPTS="-conform_schema ${__schema_file} -conform_config ${__conform_file}"
             result="$("$BINDIR/escript" "$__conform" --conf "$__conform_file" --schema "$__schema_file" --config "$SYS_CONFIG" --output-dir "$GENERATED_CONFIG_DIR")"
             exit_status="$?"
             if [ "$exit_status" -ne 0 ]; then


### PR DESCRIPTION
This PR is related to [exrm_reload](https://github.com/xerions/exrm_reload) and restores order with the conform options at runtime. 

Before these changes we can change config file which placed only in `__running_config` directory because here was:
```
cp "$__conform_file" "$__running_conf"
__conform_file="$__running_conf"
```

And we were setting `CONFORM_OPTS` after this.