### PR TITLE
Respect paths in project

### DIFF
--- a/lib/exrm/plugin.ex
+++ b/lib/exrm/plugin.ex
@@ -92,7 +92,7 @@ defmodule ReleaseManager.Plugin do
     # Ensure the current projects code path is loaded
     Mix.Task.run("loadpaths", [])
     # Fetch all .beam files
-    Path.wildcard("**/*/ebin/**/*.{beam}")
+    Path.wildcard(Path.join([Mix.Project.build_path, "**/ebin/**/*.beam"]))
     # Parse the BEAM for behaviour implementations
     |> Stream.map(fn path ->
       {:ok, {mod, chunks}} = :beam_lib.chunks('#{path}', [:attributes])

--- a/lib/exrm/plugins/consolidation.ex
+++ b/lib/exrm/plugins/consolidation.ex
@@ -27,7 +27,7 @@ defmodule ReleaseManager.Plugin.Consolidation do
       debug "Packaging consolidated protocols..."
 
       # Add overlay to relx.config which copies consolidated dir to release
-      consolidated_path = Path.join([File.cwd!, "_build", "#{env}", "consolidated"])
+      consolidated_path = Path.join([Mix.Project.build_path, "consolidated"])
       case File.ls(consolidated_path) do
         {:error, _} -> :ok
         {:ok, filenames} ->

--- a/lib/exrm/utils/utils.ex
+++ b/lib/exrm/utils/utils.ex
@@ -27,10 +27,11 @@ defmodule ReleaseManager.Utils do
   @doc """
   Load the current project's configuration
   """
-  def load_config(env) do
+  def load_config(env, project_config \\ Mix.Project.config) do
+    config_path = Keyword.get(project_config, :config_path, "config/config.exs")
     with_env env, fn ->
-      if File.regular?("config/config.exs") do
-        Mix.Config.read! "config/config.exs"
+      if File.regular?(config_path) do
+        Mix.Config.read! config_path
       else
         []
       end

--- a/lib/mix/tasks/release.clean.ex
+++ b/lib/mix/tasks/release.clean.ex
@@ -52,10 +52,9 @@ defmodule Mix.Tasks.Release.Clean do
 
   # Clean release build
   def do_cleanup(:build) do
-    cwd       = File.cwd!
     project   = Mix.Project.config |> Keyword.get(:app) |> Atom.to_string
     version   = Mix.Project.config |> Keyword.get(:version)
-    build     = Path.join([cwd, "_build", "prod"])
+    build     = Path.absname("../prod", Mix.Project.build_path)
     release   = rel_dest_path [project, "releases", version]
     releases  = rel_dest_path [project, "releases", "RELEASES"]
     start_erl = rel_dest_path [project, "releases", "start_erl.data"]

--- a/lib/mix/tasks/release.ex
+++ b/lib/mix/tasks/release.ex
@@ -109,7 +109,7 @@ defmodule Mix.Tasks.Release do
     end
   end
 
-  defp generate_relx_config(%Config{name: name, version: version, env: env} = config) do
+  defp generate_relx_config(%Config{name: name, version: version} = config) do
     Logger.debug "Generating relx configuration..."
     # Get paths
     rel_def  = rel_file_source_path @_RELEASE_DEF
@@ -129,12 +129,11 @@ defmodule Mix.Tasks.Release do
       _  -> %{config | :upgrade? => true}
     end
     elixir_paths = get_elixir_lib_paths |> Enum.map(&String.to_char_list/1)
-    lib_dirs = case Mix.Project.config |> Keyword.get(:umbrella?, false) do
+    lib_dirs = case Mix.Project.umbrella? do
       true ->
-        [ '#{"_build/#{env}" |> Path.expand}',
-          '#{Mix.Project.config |> Keyword.get(:deps_path) |> Path.expand}' | elixir_paths ]
+        [ '#{Mix.Project.build_path}', '#{Mix.Project.deps_path}' | elixir_paths ]
       _ ->
-        [ '#{"_build/#{env}" |> Path.expand}' | elixir_paths ]
+        [ '#{Mix.Project.build_path}' | elixir_paths ]
     end
     # Build release configuration
     relx_config = relx_config
@@ -313,7 +312,7 @@ defmodule Mix.Tasks.Release do
         app      = name |> String.to_atom
         v1       = get_last_release(name)
         v1_path  = rel_dest_path [name, "lib", "#{name}-#{v1}"]
-        v2_path  = Mix.Project.config |> Mix.Project.compile_path |> String.replace("/ebin", "")
+        v2_path  = Mix.Project.compile_path |> String.replace("/ebin", "")
         own_path = rel_dest_path "#{name}.appup"
         # Look for user's own .appup file before generating one
         case own_path |> File.exists? do

--- a/test/fixtures/example_app/config/explicit_config.exs
+++ b/test/fixtures/example_app/config/explicit_config.exs
@@ -1,0 +1,3 @@
+use Mix.Config
+
+config :test, foo: :explicit

--- a/test/utils_test.exs
+++ b/test/utils_test.exs
@@ -50,6 +50,14 @@ defmodule UtilsTest do
     end
   end
 
+  test "can load the current project configuration from project's specified location" do
+    project_config = [config_path: "config/explicit_config.exs"]
+    with_app do
+      [test: config] = Utils.load_config(:prod, project_config)
+      assert Keyword.fetch!(config, :foo) == :explicit
+    end
+  end
+
   test "can invoke mix to perform a task for a given environment" do
     with_app do
       assert :ok = Utils.mix("clean", :prod)


### PR DESCRIPTION
Elixir 1.2 Mix introduced a fantastic feature: an ability to share `_build` for in-umbrella applications. It greatly improved development speed.

In order to do that, projects `mix.exs` allows new (or activated) parameters:

```ex
  def project do
    [
      # . . . .
      build_path: "../../_build",
      config_path: "../../config/config.exs",
      # . . . .
    ]
  end
```

This PR introduces support for them, and does a minor consolidation of `_build` path handling.