### PR TITLE
always add build path to lib_dirs

### DIFF
--- a/lib/mix/tasks/release.ex
+++ b/lib/mix/tasks/release.ex
@@ -129,12 +129,7 @@ defmodule Mix.Tasks.Release do
       _  -> %{config | :upgrade? => true}
     end
     elixir_paths = get_elixir_lib_paths |> Enum.map(&String.to_char_list/1)
-    lib_dirs = case Mix.Project.umbrella? do
-      true ->
-        [ '#{Mix.Project.build_path}', '#{Mix.Project.deps_path}' | elixir_paths ]
-      _ ->
-        [ '#{Mix.Project.build_path}' | elixir_paths ]
-    end
+    lib_dirs = [ '#{Mix.Project.build_path}', '#{Mix.Project.deps_path}' | elixir_paths ]
     # Build release configuration
     relx_config = relx_config
       |> String.replace(@_RELEASES, releases)


### PR DESCRIPTION
When using an umbrella project configuration, `mix` will build an app configuration similar to this:

```elixir
  def project do
    [app: :app_one,
     version: "0.0.1",
     build_path: "../../_build",
     config_path: "../../config/config.exs",
     deps_path: "../../deps",
     lockfile: "../../mix.lock",
     elixir: "~> 1.0",
     deps: deps]
  end
```

This results in a shared `_build` folder among all the apps rather than a `_build` folder in each individual app's own folder.

When building a release for an individual app an error is encountered where `exrm` can not find where the app itself has been built when it is using the shared `_build` folder in the root of the umbrella project.  This PR corrects that.

All the tests that run with `mix test` pass when I run them.