### PR TITLE
modify `priv/rel/files/boot` so it can run elixir in command-line mode.

### DIFF
--- a/priv/rel/files/boot
+++ b/priv/rel/files/boot
@@ -588,8 +588,34 @@ case "$1" in
         # Start the VM
         exec "$@" -- ${1+$ARGS}
         ;;
+
+    command)
+        # Make sure the config is generated first
+        generate_config
+        # Execute as command-line utility
+
+        shift
+        MODULE="$1"; shift
+        FUNCTION="$1"; shift
+
+        # Save extra arguments
+        ARGS="$@"
+
+        # Build arguments for erlexec
+        set -- "$ERL_OPTS"
+        [ "$SYS_CONFIG" ] && set -- "$@" -config "$SYS_CONFIG"
+        [ "$VMARGS_PATH" ] && set -- "$@" -args_file "$VMARGS_PATH"
+        set -- "$@" -boot_var ERTS_LIB_DIR "$ERTS_LIB_DIR"
+        set -- "$@" -noshell
+        set -- "$@" -boot $REL_DIR/start
+        set -- "$@" -s "$MODULE" "$FUNCTION"
+
+        # Boot the release
+        $BINDIR/erlexec $@ -extra $ARGS
+        ;;
+
     *)
-        echo "Usage: $REL_NAME {start|start_boot <file>|foreground|stop|restart|reboot|ping|rpc <m> <f> [<a>]|console|console_clean|console_boot <file>|attach|remote_console|upgrade|escript}"
+        echo "Usage: $REL_NAME {start|start_boot <file>|foreground|stop|restart|reboot|ping|rpc <m> <f> [<a>]|console|console_clean|console_boot <file>|attach|remote_console|upgrade|escript|command <m> <f> <args>}"
         exit 1
         ;;
 esac


### PR DESCRIPTION
With this change, assuming that we have `hello_cli.ex` in the project `test_cli` with following content:

```ex
defmodule HelloCli do
  @spec main() :: no_return
  def main() do
    # print greeting
    IO.puts "HelloCli.main() is running"

    # print command-line args
    :init.get_plain_arguments()
    |> Enum.map(&String.Chars.to_string/1)
    |> Enum.each(&IO.puts/1)

    # set exit code to 4
    System.halt(4)
  end
end
```

We can release it, and then run 

```bash
bin/test_cli command Elixir.HelloCli main foo bar baz
```

The command above prints:
```
Using /home/vadim/moz/ex/test/rel/test/releases/0.0.1/test.sh
HelloCli.main() is running
foo
bar
baz
```
