### PR TITLE
make boot_shim work when there is a symlink to it

### DIFF
--- a/priv/rel/files/boot_shim
+++ b/priv/rel/files/boot_shim
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-SCRIPT_DIR="$(dirname "$0")"
+SCRIPT_DIR="$(dirname $(readlink -f "$0"))"
 RELEASE_ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 RELEASES_DIR="$RELEASE_ROOT_DIR/releases"
 REL_NAME="{{{PROJECT_NAME}}}"


### PR DESCRIPTION
Title says it all. This fix makes it possible to create a symlink to boot_shim.