### PR TITLE
Fix the link to the documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 Status](https://travis-ci.org/bitwalker/exrm.svg?branch=master)](https://travis-ci.org/bitwalker/exrm)
 [![Hex.pm Version](http://img.shields.io/hexpm/v/exrm.svg?style=flat)](https://hex.pm/packages/exrm) [![Coverage Status](https://coveralls.io/repos/bitwalker/exrm/badge.svg?branch=master&service=github)](https://coveralls.io/github/bitwalker/exrm?branch=master)
 
-The full documentation for Exrm is located [here](https://hexdocs.pm/exrm).
+The full documentation for Exrm is located [here](http://hexdocs.pm/exrm).
 
 Thanks to @tylerflint for the original Makefile, rel.config, and runner script which inspired this project!
 


### PR DESCRIPTION
`HTTPS` to hexdocs results in one of those scary _Your connection is not private_ warning messages.