### PR TITLE
Limit lib to build_path/lib

### DIFF
--- a/lib/exrm/plugin.ex
+++ b/lib/exrm/plugin.ex
@@ -92,7 +92,7 @@ defmodule ReleaseManager.Plugin do
     # Ensure the current projects code path is loaded
     Mix.Task.run("loadpaths", [])
     # Fetch all .beam files
-    Path.wildcard(Path.join([Mix.Project.build_path, "*/*/ebin/**/*.beam"]))
+    Path.wildcard(Path.join([Mix.Project.build_path, "lib/**/ebin/**/*.beam"]))
     # Parse the BEAM for behaviour implementations
     |> Stream.map(fn path ->
       case :beam_lib.chunks(path, [:attributes]) do

--- a/lib/exrm/plugin.ex
+++ b/lib/exrm/plugin.ex
@@ -92,7 +92,7 @@ defmodule ReleaseManager.Plugin do
     # Ensure the current projects code path is loaded
     Mix.Task.run("loadpaths", [])
     # Fetch all .beam files
-    Path.wildcard(Path.join([Mix.Project.build_path, "**/ebin/**/*.beam"]))
+    Path.wildcard(Path.join([Mix.Project.build_path, "*/*/ebin/**/*.beam"]))
     # Parse the BEAM for behaviour implementations
     |> Stream.map(fn path ->
       case :beam_lib.chunks(path, [:attributes]) do

--- a/lib/exrm/plugin.ex
+++ b/lib/exrm/plugin.ex
@@ -93,6 +93,7 @@ defmodule ReleaseManager.Plugin do
     Mix.Task.run("loadpaths", [])
     # Fetch all .beam files
     Path.wildcard(Path.join([Mix.Project.build_path, "lib/**/ebin/**/*.beam"]))
+    |> Stream.map(&String.to_char_list/1)
     # Parse the BEAM for behaviour implementations
     |> Stream.map(fn path ->
       case :beam_lib.chunks(path, [:attributes]) do

--- a/lib/mix/tasks/release.ex
+++ b/lib/mix/tasks/release.ex
@@ -126,7 +126,7 @@ defmodule Mix.Tasks.Release do
       _  -> %{config | :upgrade? => true}
     end
     elixir_paths = get_elixir_lib_paths |> Enum.map(&String.to_char_list/1)
-    lib_dirs = [ '#{Mix.Project.build_path}', '#{Mix.Project.deps_path}' | elixir_paths ]
+    lib_dirs = [ '#{Path.join(Mix.Project.build_path, "lib")}', '#{Mix.Project.deps_path}' | elixir_paths ]
     # Build release configuration
     relx_config = relx_config
       |> String.replace(@_RELEASES, releases)


### PR DESCRIPTION
As part of the compile process for applications and dependencies, it is possible that these apps will create build assets in the `Mix.Project.build_path`. These assets should not be included as part of the process of creating a release, only the contents of the  `#{Mix.Project.build_path}/lib` dir should. As per a conversation with @josevalim. I am open to discussing this a little further to prevent any situations where this would actually produce a breaking change, but I am under the assumption that it would not.