### PR TITLE
boot: conform does not create vm.args so install unconditionally

### DIFF
--- a/priv/rel/files/boot
+++ b/priv/rel/files/boot
@@ -130,10 +130,10 @@ generate_config() {
         fi
     else
         cp $RELEASE_SYS_CONFIG "$GENERATED_CONFIG_DIR/sys.config"
-        if [ ! -f "$VMARGS_PATH" ]; then
-            cp "$RELEASE_CONFIG_DIR/vm.args" "$GENERATED_CONFIG_DIR/vm.args"
-            VMARGS_PATH="$GENERATED_CONFIG_DIR/vm.args"
-        fi
+    fi
+    if [ ! -f "$VMARGS_PATH" ]; then
+        cp "$RELEASE_CONFIG_DIR/vm.args" "$GENERATED_CONFIG_DIR/vm.args"
+        VMARGS_PATH="$GENERATED_CONFIG_DIR/vm.args"
     fi
 }
 


### PR DESCRIPTION
Current logic around conform and `vm.args` assumes that `vm.args` will be created by conform. However, current conform does not create vm.args.

This trivial PR fixes this.

