### PR TITLE
Doc fixes

### DIFF
--- a/docs/Getting Started.md
+++ b/docs/Getting Started.md
@@ -18,7 +18,7 @@ You can build a release with the `release` task:
 
 ```
 $ mix release
-````
+```
 
 This task constructs the complete release for you. The output is sent to `rel/<project>`. To see what flags you can pass to this task, use `mix help release`.
 

--- a/mix.exs
+++ b/mix.exs
@@ -38,7 +38,7 @@ defmodule ReleaseManager.Mixfile do
   end
 
   defp docs do
-    [main: "extra-getting-started",
+    [main: "getting-started",
      extras: [
         "docs/Getting Started.md",
         "docs/Release Configuration.md",


### PR DESCRIPTION
Fixes a code fence typo in the getting started document, as well as setting the right main target for documentation. Should fix #344 after docs are re-pushed to hexdocs