### PR TITLE
Fix docs root path

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -38,7 +38,7 @@ defmodule ReleaseManager.Mixfile do
   end
 
   defp docs do
-    [main: "extra-getting-started",
+    [main: "getting-started",
      extras: [
         "docs/Getting Started.md",
         "docs/Release Configuration.md",


### PR DESCRIPTION
Right now `https://hexdocs.pm/exrm/` redirects to `https://hexdocs.pm/exrm/extra-getting-started.html`, which is a 404.