### PR TITLE
Fix broken docs main

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -38,7 +38,7 @@ defmodule ReleaseManager.Mixfile do
   end
 
   defp docs do
-    [main: "extra-getting-started",
+    [main: "getting-started",
      extras: [
         "docs/Getting Started.md",
         "docs/Release Configuration.md",


### PR DESCRIPTION
It looks like the main docs page is https://hexdocs.pm/exrm/getting-started.html

But going to the index page on hexdocs takes you to https://hexdocs.pm/exrm/extra-getting-started.html (which doesn't exist)