### PR TITLE
boot: add pingpeer command

### DIFF
--- a/priv/rel/files/boot
+++ b/priv/rel/files/boot
@@ -70,10 +70,11 @@ relx_gen_id() {
     od -t x4 /dev/urandom | head -n1 | cut -d ' ' -f2
 }
 
-# Control a node
+# Control a node - set PEERNAME to control a peer node
 relx_nodetool() {
     command="$1"; shift
-    "$BINDIR/escript" "$ROOTDIR/bin/nodetool" "$NAME_TYPE" "$NAME" \
+    name=${PEERNAME:-$NAME}
+    "$BINDIR/escript" "$ROOTDIR/bin/nodetool" "$NAME_TYPE" "$name" \
                                  -setcookie "$COOKIE" "$command" "$@"
 }
 
@@ -341,6 +342,14 @@ case "$1" in
     ping)
         ## See if the VM is alive
         relx_nodetool "ping"
+        exit_status=$?
+        if [ "$exit_status" -ne 0 ]; then
+            exit $exit_status
+        fi
+        ;;
+
+    pingpeer)
+        PEERNAME=$2 relx_nodetool "ping"
         exit_status=$?
         if [ "$exit_status" -ne 0 ]; then
             exit $exit_status


### PR DESCRIPTION
Allows installed node ping other nodes in an OTP cluster.

~

Use case: we have an application running over a cluster, with different roles. Nodes of role B should not come up unless they can ping a node of role A. It is valuable to use nodetool (from the release) to try ping a peer as part of the controlling init script.