### PR TITLE
Remove VMARGS_FILE from "command" release command

### DIFF
--- a/priv/rel/files/boot
+++ b/priv/rel/files/boot
@@ -630,7 +630,6 @@ case "$1" in
         # Build arguments for erlexec
         set -- "$ERL_OPTS"
         [ "$SYS_CONFIG" ] && set -- "$@" -config "$SYS_CONFIG"
-        [ "$VMARGS_PATH" ] && set -- "$@" -args_file "$VMARGS_PATH"
         set -- "$@" -boot_var ERTS_LIB_DIR "$ERTS_LIB_DIR"
         set -- "$@" -noshell
         set -- "$@" -boot $REL_DIR/start_clean


### PR DESCRIPTION
As per #367, this is a patch that removes invoking vm.args when running the `bin/release command` command. VM args are generally for the actual running process, and reusing `sname` may cause issues when running commands on a server with a running node.