### PR TITLE
set the permissions to 0o0600 on sys.config

### DIFF
--- a/lib/mix/tasks/release.ex
+++ b/lib/mix/tasks/release.ex
@@ -183,6 +183,8 @@ defmodule Mix.Tasks.Release do
     File.mkdir_p!(dest |> Path.dirname)
     # Write the config to disk
     dest |> Utils.write_term(merged)
+    # tighten permissions on sys.config to owner read/write
+    dest |> File.chmod(0o0600)
     # Continue..
     config
   end

--- a/test/utils_test.exs
+++ b/test/utils_test.exs
@@ -1,5 +1,7 @@
 defmodule UtilsTest do
   use ExUnit.Case, async: true
+  use Bitwise, only_operators: true
+
   import ExUnit.CaptureIO
 
   import PathHelpers
@@ -94,6 +96,9 @@ defmodule UtilsTest do
         assert :ok = res
         some_val = Keyword.get(List.first(sysconfig_content), :test) |> Keyword.get(:some_val)
         assert 101 = some_val
+        sys_config_rel_path = Path.join([File.cwd!, "rel", "test", "releases", "0.0.1", "sys.config"])
+         {:ok, info } = File.stat(sys_config_rel_path)
+         assert (info.mode &&& 0o0777) == 0o600
       #end)
     end
   end


### PR DESCRIPTION
I just added a File.chmod to set the permissions to 0o0600 on sys.config and a test to check that it was set. Let me know if you'd like to see something else.  Fixes #380 