### PR TITLE
Strip ANSI color codes in non-TTY mode

### DIFF
--- a/lib/exrm/utils/logger.ex
+++ b/lib/exrm/utils/logger.ex
@@ -5,15 +5,15 @@ defmodule ReleaseManager.Utils.Logger do
   end
 
   @doc "Print an informational message without color"
-  def debug(message),  do: log(:debug, "==> #{message}")
+  def debug(message),  do: log(:debug, IO.ANSI.format(["==> ", message]))
   @doc "Print an informational message in green"
-  def info(message),   do: log(:info, "==> #{IO.ANSI.green}#{message}#{IO.ANSI.reset}")
+  def info(message),   do: log(:info, IO.ANSI.format(["==> ", :green, message]))
   @doc "Print a warning message in yellow"
-  def warn(message),   do: log(:warn, "==> #{IO.ANSI.yellow}#{message}#{IO.ANSI.reset}")
+  def warn(message),   do: log(:warn, IO.ANSI.format(["==> ", :yellow, message]))
   @doc "Print a notice in yellow"
-  def notice(message), do: log(:notice, "#{IO.ANSI.yellow}#{message}#{IO.ANSI.reset}")
+  def notice(message), do: log(:notice, IO.ANSI.format([:yellow, message]))
   @doc "Print an error message in red"
-  def error(message),  do: log(:error, "==> #{IO.ANSI.red}#{message}#{IO.ANSI.reset}")
+  def error(message),  do: log(:error, IO.ANSI.format(["==> ", :red, message]))
 
   defp log(level, message), do: log(level, Application.get_env(:exrm, :verbosity, :normal), message)
 


### PR DESCRIPTION
When running `mix release` non-interactively, for example as part of a script,
we should not see color codes mixed with the output. This can be tested by
piping the output of mix.release. E.g.:

```
# Colors visible:
mix release

# No colors
mix release | cat
```