### PR TITLE
Fixes concerning RELX_REPLACE_OS_VARS

### DIFF
--- a/priv/rel/files/boot
+++ b/priv/rel/files/boot
@@ -179,9 +179,9 @@ if [ ! -f "$VMARGS_PATH" ]; then
     cp "$RELEASE_CONFIG_DIR/vm.args" "$GENERATED_CONFIG_DIR/vm.args"
 fi
 
-if [ $RELX_REPLACE_OS_VARS ]; then
+if [ "$RELX_REPLACE_OS_VARS" = "true" ]; then
     _replace_os_vars "$VMARGS_PATH" "$VMARGS_PATH.2.config"
-    VMARGS_PATH=$VMARGS_PATH.2.config
+    mv "$VMARGS_PATH.2.config" $VMARGS_PATH
 fi
 
 # Make sure log directory exists
@@ -193,9 +193,9 @@ if ! [ -w $RUNNER_LOG_DIR ] ; then
     exit 1
 fi
 
-if [ $RELX_REPLACE_OS_VARS ]; then
+if [ "$RELX_REPLACE_OS_VARS" = "true" ]; then
     _replace_os_vars "$SYS_CONFIG" "$SYS_CONFIG.2.config"
-    SYS_CONFIG=$SYS_CONFIG.2.config
+    mv "$SYS_CONFIG.2.config" $SYS_CONFIG
 fi
 
 # Extract the target node name from node.args


### PR DESCRIPTION
- only replace variables when RELX_REPLACE_OS_VARS=true
- overwrite old sys.config and vm.args from
  ${RELEASE_MUTABLE_DIR}/running-config with the processed files
  instead of using copies which are not compatible in their
  naming with OTP.

The last fix in particular solves an issue where changes in the
.conf file of the release folder are only honored after the
SECOND start of the release.

See also
- erlang/rebar3#731
- erlware/relx@447df92
