### PR TITLE
Escape slashes before config file generation

### DIFF
--- a/priv/rel/files/boot
+++ b/priv/rel/files/boot
@@ -32,7 +32,7 @@ RUNNER_LOG_DIR="${RUNNER_LOG_DIR:-$RELEASE_ROOT_DIR/log}"
 _replace_os_vars() {
     awk '
         function escape(s) {
-            gsub(/'\&'/, "\\\\&", s);
+            gsub(/\\/, "\\\\", s);
             return s;
         }
         {

--- a/priv/rel/files/boot
+++ b/priv/rel/files/boot
@@ -33,6 +33,7 @@ _replace_os_vars() {
     awk '
         function escape(s) {
             gsub(/\\/, "\\\\", s);
+            gsub(/\&/, "\\\\&", s);
             return s;
         }
         {


### PR DESCRIPTION
Hello.

I've found out that with `RELX_REPLACE_OS_VARS=true` exrm generates invalid runtime configuration files if ENV variables contain slashes.

In our case we've experienced application crash with error
```
could not start kernel pid (application_controller) (error in config file "/app/rel/application/running-config/sys.config.2.config" (none): no ending <dot> found)
```
because one of envirionment variables ended with slash.

