### PR TITLE
release upgrade was not working for Windows due to simple problems in bat file

### DIFF
--- a/priv/rel/files/boot.bat
+++ b/priv/rel/files/boot.bat
@@ -221,7 +221,7 @@
   set ERRORLEVEL=1
   exit /b %ERRORLEVEL%
 )
-@%escript% "%rootdir%/bin/install_upgrade.escript" "%rel_name%" "%node_type%" "%node_name%" "%cookie%" "%2"
+@%escript% "%rootdir%/bin/install_upgrade.escript" "install" "%rel_name%" "%node_type%" "%node_name%" "%cookie%" "%2"
 @goto :eof
 
 :: Start a console

--- a/priv/rel/files/boot.bat
+++ b/priv/rel/files/boot.bat
@@ -18,7 +18,7 @@
 :: Set variables that describe the release
 @set rel_name={{{PROJECT_NAME}}}
 @set erl_opts={{{ERL_OPTS}}}
-@set conform_opts=""
+@set conform_opts=
 
 :: Discover the release root directory from the directory of this script
 @set script_dir=%~dp0


### PR DESCRIPTION
These two very small bugs cause the Windows release bat files to fail to start the node properly, which means you can't even ping it. The bug causing this is a simple error in the bat file where an options string variable is initialised to "" rather than to nothing.

Then once that was fixed, and the node was being started up as e.g. blah@127.0.0.1 and with cookie blah, then another problem still was preventing the upgrade from working, because the erlscript that was supposed to do the work was expecting an extra parameter than what was being sent to it.


boot.bat was initialising conform_opts to "", as if that was an empty string, but in a bat file its not:

@set conform_opts=""

This code was failing:

:install
@if "" == "%2" (
  :: Install the service
  set args=%erl_opts% %conform_opts% -setcookie %cookie% ++ -rootdir \"%rootdir%\"
  set svc_machine=%erts_dir%\bin\start_erl.exe
  set description=Erlang node %node_name% in %rootdir%
  %erlsrv% add %service_name% %node_type% "%node_name%" -c "%description%" ^
            -w "%rootdir%" -m "%svc_machine%" -args "%args%" ^
            -stopaction "init:stop()."

The args string had "" before the rest of the arguments (e.g. -setcookie...) whch caused them to be removed (due to how batch file arguments get expanded)

This was causing thew erlang node to be started as :"nonode@nohost", which meant you could not ping it, and the upgrade failed due to not being able to rpc to it.

So I changed the initialisation to:

@set conform_opts=

... which solved that problem, but:
I also noticed that the install_upgrade.escript, needs to be passed a first parameter of "install". I also fixed that, otherwise the upgrade does not work.